### PR TITLE
Update Pillow version to match python 3.10.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==3.1.3
 gunicorn==20.0.4
-Pillow==8.0.1
+Pillow==8.4


### PR DESCRIPTION
ibmcloud cf default python Buildpack version is 1.7.55 which comes with python 3.10.5.
The minimum Pillow version that works with this version is Pillow 8.4.
![image](https://user-images.githubusercontent.com/31776967/186213119-0295c149-368d-4adb-946a-ad45ae0915eb.png)

![image](https://user-images.githubusercontent.com/31776967/186213167-532e6f65-5c03-470a-97e4-46cef0e92723.png)
